### PR TITLE
Added vivo:rank to contacts, included NonAcademic in map.js.

### DIFF
--- a/es-indexer/lib/es-sparql-model/default-queries/map.js
+++ b/es-indexer/lib/es-sparql-model/default-queries/map.js
@@ -1,9 +1,9 @@
 module.exports = {
   // https://wiki.lyrasis.org/display/VIVODOC110x/Person+Model
-  person : ['http://xmlns.com/foaf/0.1/Person', 'http://vivoweb.org/ontology/core#FacultyMember'],
+  person : ['http://xmlns.com/foaf/0.1/Person', 'http://vivoweb.org/ontology/core#NonAcademic','http://vivoweb.org/ontology/core#FacultyMember'],
 
   // https://wiki.lyrasis.org/display/VIVODOC110x/Publication+Model
   publication : 'http://purl.org/ontology/bibo/AcademicArticle',
 
-  organization : ['http://vivoweb.org/ontology/core#AcademicDepartment', 'http://vivoweb.org/ontology/core#University']
+  organization : ['http://vivoweb.org/ontology/core#AcademicDepartment', 'http://vivoweb.org/ontology/core#College','http://vivoweb.org/ontology/core#University']
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
@@ -43,6 +43,7 @@ CONSTRUCT {
   ?contactInfoFor vcard:organization ?organization .
   ?contactInfoFor vcard:telephone ?telephone .
   ?contactInfoFor vcard:geo ?geo .
+  ?contactInfoFor vivo:rank ?vcardRank .
 
   ?contactInfoFor vcard:hasURL ?vcardURL .
   ?vcardURL vcard:url ?url .
@@ -92,6 +93,8 @@ CONSTRUCT {
         OPTIONAL { ?vcardName vcard:honorificPrefix ?honorificPrefix . }
         OPTIONAL { ?vcardName vcard:honorificSuffix ?honorificSuffix . }
       }
+
+      OPTIONAL { ?contactInfoFor vivo:rank ?vcardRank . }
 
       OPTIONAL {
         ?contactInfoFor vcard:hasEmail ?vcardEmail .


### PR DESCRIPTION
The map adds in standard NonAcedemic if foaf:Person is missing.  
vivo:rank orders the vcards from best to worst.
