### PR TITLE
Identifiers 2.0

### DIFF
--- a/api/controllers/index.js
+++ b/api/controllers/index.js
@@ -52,6 +52,7 @@ router.get('/:id', async (req, res) => {
       res.json((await model.get(id))._source);
     }
   } catch(e) {
+    console.log(e);
     errorHandler(req, res, e);
   }
 });

--- a/api/controllers/index.js
+++ b/api/controllers/index.js
@@ -23,23 +23,34 @@ router.use('/miv', require('./miv'));
  *     tags: [Get Record]
  *     parameters:
  *       - name: id
- *         description: id of record
+ *         description: id of record, comma separate for multiple id response
  *         in: path
  *         required: true
  *         schema:
  *           type: string
  *     responses:
  *       200:
- *         description: Requested record
+ *         description: Requested record(s)
  *         content:
  *          application/json:
  *            schema:
  *              type: object
- *              description: record
+ *              description: record or array of records
  */
 router.get('/:id', async (req, res) => {
   try {
-    res.json((await model.get(req.params.id))._source);
+    let id = req.params.id;
+    if( id.includes(',') ) {
+      let ids = id.split(',');
+      let arr = [];
+
+      for( id of ids ) {
+        arr.push((await model.get(id))._source);
+      }
+      res.json(arr);
+    } else {
+      res.json((await model.get(id))._source);
+    }
   } catch(e) {
     errorHandler(req, res, e);
   }

--- a/api/controllers/index.js
+++ b/api/controllers/index.js
@@ -12,6 +12,7 @@ router.get('/', (req, res) => {
 });
 
 router.use('/search', require('./search'));
+router.use('/miv', require('./miv'));
 
 /**
  * @swagger

--- a/api/controllers/index.js
+++ b/api/controllers/index.js
@@ -13,6 +13,7 @@ router.get('/', (req, res) => {
 
 router.use('/search', require('./search'));
 router.use('/miv', require('./miv'));
+router.use('/subject-terms', require('./subject-terms'));
 
 /**
  * @swagger

--- a/api/controllers/miv.js
+++ b/api/controllers/miv.js
@@ -3,6 +3,26 @@ const model = require('../models/miv');
 const onError = require('./utils/error-handler');
 const {auth} = require('@ucd-lib/rp-node-utils');
 
+/**
+ * @swagger
+ *
+ * /api/miv/{username}:
+ *   get:
+ *     description: Get researchers ris formatted publication list
+ *     tags: [MIV RIS Export]
+ *     parameters:
+ *       - name: username
+ *         description: id of researcher
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: ris formatted citations
+ *         content:
+ *          text/plain
+ */
 router.get('/:username', async (req, res) => {
 
   try {

--- a/api/controllers/miv.js
+++ b/api/controllers/miv.js
@@ -1,0 +1,32 @@
+const router = require('express').Router();
+const model = require('../models/miv');
+const onError = require('./utils/error-handler');
+const {auth} = require('@ucd-lib/rp-node-utils');
+
+router.get('/:username', async (req, res) => {
+
+  try {
+    let username = req.params.username;
+    if( !username ) {
+      let user = null;
+      let token = auth.getTokenFromRequest(req);
+      if( token ) {
+        try {
+          user = await auth.verifyToken(token);
+          username = user.username.replace(/@.*/, '');
+        } catch(e) {}
+      }
+    }
+
+    if( !username ) {
+      return onError(req, res, new Error('Invalid parameters'), 'You must be logged in or supply a username');
+    }
+
+    res.send(await model.export(username));
+  } catch(e) {
+    onError(req, res, e, 'Failed to generate MIV export');
+  }
+
+});
+
+module.exports = router;

--- a/api/controllers/miv.js
+++ b/api/controllers/miv.js
@@ -22,6 +22,8 @@ router.get('/:username', async (req, res) => {
       return onError(req, res, new Error('Invalid parameters'), 'You must be logged in or supply a username');
     }
 
+    res.set('content-type', 'text/plain');
+    res.set('Content-Disposition', `attachment; filename="${username}.ris"`);
     res.send(await model.export(username));
   } catch(e) {
     onError(req, res, e, 'Failed to generate MIV export');

--- a/api/controllers/subject-terms.js
+++ b/api/controllers/subject-terms.js
@@ -1,0 +1,65 @@
+const router = require('express').Router();
+const model = require('../models/subject-terms');
+const onError = require('./utils/error-handler');
+
+/**
+ * @swagger
+ *
+ * /api/subject-term/broader/{id}:
+ *   get:
+ *     description: Get broader terms for provided subject id
+ *     tags: [Subject Term Broader]
+ *     parameters:
+ *       - name: id
+ *         description: id of subject term
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Terms array
+ *         content:
+ *           application/json:
+ *              schema:
+ *                type: object
+ */
+router.get('/broader/:id', async (req, res) => {
+  try {
+    res.send(await model.broader(req.params.id));
+  } catch(e) {
+    onError(req, res, e, 'Failed to get broader terms');
+  }
+});
+
+/**
+ * @swagger
+ *
+ * /api/subject-term/narrower/{id}:
+ *   get:
+ *     description: Get narrower terms for provided subject id
+ *     tags: [Subject Term Narrower]
+ *     parameters:
+ *       - name: id
+ *         description: id of subject term
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Terms array
+ *         content:
+ *           application/json:
+ *              schema:
+ *                type: object
+ */
+router.get('/narrower/:id', async (req, res) => {
+  try {
+    res.send(await model.narrower(req.params.id));
+  } catch(e) {
+    onError(req, res, e, 'Failed to get narrower terms');
+  }
+});
+
+module.exports = router;

--- a/api/controllers/swagger/spec.json
+++ b/api/controllers/swagger/spec.json
@@ -19,7 +19,7 @@
         "parameters": [
           {
             "name": "id",
-            "description": "id of record",
+            "description": "id of record, comma separate for multiple id response",
             "in": "path",
             "required": true,
             "schema": {
@@ -29,12 +29,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Requested record",
+            "description": "Requested record(s)",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "description": "record"
+                  "description": "record or array of records"
                 }
               }
             }

--- a/api/lib/citation.js
+++ b/api/lib/citation.js
@@ -7,8 +7,29 @@ class Citation {
   }
 
   convert(data, opts={}) {
-    if( !opts.style ) opts.style = 'ris';
-    return this.engine.set(data).format('bibliography',opts);
+    // if( !opts.style ) opts.style = 'ris';
+    // opts.format = 'string';
+
+    // HACK for demo
+    data = data.map(item => {
+      item.id = item['@id'];
+      delete item['@id'];
+      item.author.forEach(a => {
+        a.id = a['@id'];
+        delete a['cite:rank'];
+        delete a['@id'];
+      });
+
+      if( item.venue ) {
+        item.venue = {id: item.venue};
+      }
+      item.type = 'article';
+
+      return item;
+    });
+
+    return this.engine.set(data).format('ris');
+    // this.engine.set(data).get(opts);
   }
 
 

--- a/api/lib/citation.js
+++ b/api/lib/citation.js
@@ -8,7 +8,7 @@ class Citation {
 
   convert(data, opts={}) {
     if( !opts.style ) opts.style = 'ris';
-    return this.engine.set(data).get(opt);
+    return this.engine.set(data).format('bibliography',opts);
   }
 
 

--- a/api/lib/search-utils.js
+++ b/api/lib/search-utils.js
@@ -1,3 +1,4 @@
+const {logger} = require('@ucd-lib/rp-node-utils');
 
 class SearchModelUtils {
 
@@ -38,6 +39,11 @@ class SearchModelUtils {
         response.results = esResult.hits.hits
           .map(item => {
             item._source._score = item._score;
+            if( item.highlight ) {
+              let field = Object.keys(item.highlight)[0];
+              item._source._snippet = {field, value : item.highlight[field][0]}
+              console.log(item._source._snippet);
+            }            
             return item._source;
           });
       }
@@ -97,6 +103,12 @@ class SearchModelUtils {
    */
   searchDocumentToEsBody(query, noLimit=false) {
     let esBody = {
+      highlight : {
+        order: 'score',
+        fields: {
+          "*": {}
+        }
+      },
       from : query.offset !== undefined ? query.offset : 0,
       size : query.limit !== undefined ? query.limit : 10
     }

--- a/api/lib/search-utils.js
+++ b/api/lib/search-utils.js
@@ -127,6 +127,7 @@ class SearchModelUtils {
       esBody.query.bool.must = [{
         multi_match : {
           query : query.text,
+          type : 'most_fields',
           fields : query.textFields
         }
       }];

--- a/api/lib/search-utils.js
+++ b/api/lib/search-utils.js
@@ -42,7 +42,6 @@ class SearchModelUtils {
             if( item.highlight ) {
               let field = Object.keys(item.highlight)[0];
               item._source._snippet = {field, value : item.highlight[field][0]}
-              console.log(item._source._snippet);
             }            
             return item._source;
           });

--- a/api/models/elastic-search.js
+++ b/api/models/elastic-search.js
@@ -34,7 +34,7 @@ class ElasticSearch {
       index: config.elasticSearch.indexAlias,
       type: '_all',
       id: id,
-      _source_exclude : config.elasticSearch.fields.exclude
+      _source_excludes : config.elasticSearch.fields.exclude.join(',')
     }
 
     return this.client.get(queryDoc);
@@ -52,7 +52,7 @@ class ElasticSearch {
   search(body = {}, options={}) {
     options.index = config.elasticSearch.indexAlias;
     options.body = body;
-    options._source_exclude = config.elasticSearch.fields.exclude;
+    options._source_excludes = config.elasticSearch.fields.exclude.join(',');
 
     return this.client.search(options);
   }

--- a/api/models/miv/author-publications.tpl.rq
+++ b/api/models/miv/author-publications.tpl.rq
@@ -1,19 +1,19 @@
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX bibo: <http://purl.org/ontology/bibo/>
-PREFIX vivo: <http://vivoweb.org/ontology/core#>
-PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
-PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-PREFIX cito: <http://purl.org/spar/cito/>
-PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
-PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX purl: <http://purl.org/ontology/bibo/>
-PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf>
 PREFIX cite: <http://citationstyles.org/schema/>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX experts: <http://experts.ucdavis.edu/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX purl: <http://purl.org/ontology/bibo/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
+PREFIX vivo: <http://vivoweb.org/ontology/core#>
+PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 SELECT ?publication
 WHERE {

--- a/api/models/miv/author-publications.tpl.rq
+++ b/api/models/miv/author-publications.tpl.rq
@@ -1,0 +1,29 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX bibo: <http://purl.org/ontology/bibo/>
+PREFIX vivo: <http://vivoweb.org/ontology/core#>
+PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ucd: <http://ucdavis.edu/ns/>
+PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX purl: <http://purl.org/ontology/bibo/>
+PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf>
+PREFIX cite: <http://citationstyles.org/schema/>
+
+SELECT ?publication
+WHERE {
+  bind ({{username}} as ?author)
+
+  GRAPH ?g {
+    ?subject rdf:type vivo:Authorship .
+    ?subject vivo:relates ?author .
+    ?subject vivo:relates ?publication .
+    ?publication rdf:type bibo:AcademicArticle .
+  }
+}

--- a/api/models/miv/index.js
+++ b/api/models/miv/index.js
@@ -31,11 +31,8 @@ class Miv {
 
       graph = graph['@graph'] ? graph['@graph'] : graph;
       pubs[i] = this.formatAuthors(this.getPub(graph), graph);
-      // pubs[i] = pubs[i];
-
       // if( i === 5 ) break;
     }
-    // pubs = pubs.splice(0, 5);
     
     return citation.convert(pubs);
   }

--- a/api/models/miv/index.js
+++ b/api/models/miv/index.js
@@ -2,7 +2,6 @@ const citation = require('../../lib/citation');
 const {fuseki} = require('@ucd-lib/rp-node-utils');
 const fs = require('fs');
 const path = require('path');
-const { pbkdf2Sync } = require('crypto');
 
 class Miv {
 

--- a/api/models/miv/index.js
+++ b/api/models/miv/index.js
@@ -13,8 +13,8 @@ class Miv {
   }
 
   async export(user) {
-    if( !user.match(/^ucdrp:/) ) {
-      user = 'ucdrp:'+user;
+    if( !user.match(/^experts:/) ) {
+      user = 'experts:'+user;
     }
 
     let q = this.QUERIES.AUTHOR_PUBS.replace(/{{username}}/, user);
@@ -32,7 +32,7 @@ class Miv {
       pubs[i] = this.formatAuthors(this.getPub(graph), graph);
       // if( i === 5 ) break;
     }
-    
+
     return citation.convert(pubs);
   }
 
@@ -40,8 +40,8 @@ class Miv {
     if( !Array.isArray(graph) ) return graph;
 
     return graph.find(
-      item => Array.isArray(item['@type']) ? 
-        item['@type'].includes('bibo:AcademicArticle') : 
+      item => Array.isArray(item['@type']) ?
+        item['@type'].includes('bibo:AcademicArticle') :
         item['@type'] === 'bibo:AcademicArticle'
       );
   }

--- a/api/models/miv/index.js
+++ b/api/models/miv/index.js
@@ -1,9 +1,66 @@
-const citation = require('../lib/citation');
+const citation = require('../../lib/citation');
+const {fuseki} = require('@ucd-lib/rp-node-utils');
+const fs = require('fs');
+const path = require('path');
+const { pbkdf2Sync } = require('crypto');
 
 class Miv {
 
-  export(user) {
+  constructor() {
+    this.QUERIES = {
+      PUBLICATIONS : fs.readFileSync(path.resolve(__dirname, 'publications.tpl.rq'), 'utf-8'),
+      AUTHOR_PUBS : fs.readFileSync(path.resolve(__dirname, 'author-publications.tpl.rq'), 'utf-8')
+    }
+  }
 
+  async export(user) {
+    if( !user.match(/^ucdrp:/) ) {
+      user = 'ucdrp:'+user;
+    }
+
+    let q = this.QUERIES.AUTHOR_PUBS.replace(/{{username}}/, user);
+    let resp = await fuseki.query(q);
+    let pubs = await resp.json();
+
+    pubs = pubs.results.bindings.map(r => r.publication.value);
+    for( let i = 0; i < pubs.length; i++ ) {
+      let q = this.QUERIES.PUBLICATIONS.replace(/{{publication}}/, pubs[i]);
+
+      let resp = await fuseki.query(q, 'application/ld+json');
+      let graph = await resp.json();
+
+      graph = graph['@graph'] ? graph['@graph'] : graph;
+      pubs[i] = this.formatAuthors(this.getPub(graph), graph);
+      // pubs[i] = pubs[i];
+
+      // if( i === 5 ) break;
+    }
+    // pubs = pubs.splice(0, 5);
+    
+    return citation.convert(pubs);
+  }
+
+  getPub(graph) {
+    if( !Array.isArray(graph) ) return graph;
+
+    return graph.find(
+      item => Array.isArray(item['@type']) ? 
+        item['@type'].includes('bibo:AcademicArticle') : 
+        item['@type'] === 'bibo:AcademicArticle'
+      );
+  }
+
+  formatAuthors(pub, graph) {
+    if( !pub.author ) pub.author = [];
+    if( !Array.isArray(pub.author) ) pub.author = [pub.author];
+
+    pub.author = pub.author.map(id => this.getAuthor(id, graph));
+    pub.author.sort((a, b) => a['cite:rank'] < b['cite:rank'] ? -1 : 1);
+    return pub;
+  }
+
+  getAuthor(id, graph) {
+    return graph.find(item => item['@id'] === id) || id;
   }
 
 }

--- a/api/models/miv/publications.tpl.rq
+++ b/api/models/miv/publications.tpl.rq
@@ -31,7 +31,7 @@ CONSTRUCT {
 
 } WHERE {
   
-  bind (ucdrp:?in_pub as ?pub)
+  bind (<{{publication}}> as ?pub)
   
   values(?pub_p ?pub_cp) {
     (rdfs:label cite:title)

--- a/api/models/subject-terms.js
+++ b/api/models/subject-terms.js
@@ -1,0 +1,98 @@
+const {elasticSearch, config} = require('@ucd-lib/rp-node-utils');
+
+class SubjectTerms {
+
+  constructor() {
+    this.connect();
+  }
+
+  /**
+   * @method connect
+   * @description setup elastic search connection using the main elastic search library
+   * and set client for this elastic search wrapper model.
+   * 
+   * @returns {Promise}
+   */
+  async connect() {
+    await elasticSearch.connect();
+    this.client = elasticSearch.client;
+  }
+
+  /**
+   * @method broader
+   * @description given id of subject term, return all broader terms
+   * 
+   * @param {String} id id of subject term
+   * @param {Array} terms results array
+   * 
+   * @returns {Array}
+   */
+  async broader(id, terms=[]) {
+    let queryDoc = {
+      index: config.elasticSearch.indexAlias,
+      type: '_all',
+      id: id,
+      _source_excludes : config.elasticSearch.fields.exclude.join(',')
+    }
+
+    let response = await this.client.get(queryDoc);
+    if( response && response._source ) {
+      terms.push(response._source);
+      let broader = response._source.broader;
+
+      if( broader ) {
+        if( !Array.isArray(broader) ) broader = [broader];
+
+        for( let term of broader ) {
+          await this.broader(term['@id'], terms);
+        }
+      }
+    }
+
+    return terms;
+  }
+
+  /**
+   * @method narrower
+   * @description given id of subject term, return all narrower terms
+   * 
+   * @param {String} id id of subject term
+   * @param {Array} terms results array
+   * 
+   * @returns {Array}
+   */
+  async narrower(id, terms=[]) {
+    let queryDoc = {
+      index: config.elasticSearch.indexAlias,
+      type: '_all',
+      id: id,
+      _source_excludes : config.elasticSearch.fields.exclude.join(',')
+    }
+
+    let response;
+
+    try {
+      response = await this.client.get(queryDoc);
+    } catch(e) {
+      return terms;
+    }
+
+    if( response && response._source ) {
+      terms.push(response._source);
+      let narrower = response._source.narrower;
+
+      if( narrower ) {
+        if( !Array.isArray(narrower) ) narrower = [narrower];
+
+        for( let term of narrower ) {
+          await this.narrower(term['@id'], terms);
+        }
+      }
+    }
+
+    return terms;
+  }
+
+}
+
+module.exports = new SubjectTerms();

--- a/es-indexer/lib/elastic-search/index.js
+++ b/es-indexer/lib/elastic-search/index.js
@@ -13,7 +13,7 @@ class ElasticSearch {
     await elasticSearch.connect();
     this.client = elasticSearch.client;
 
-    await this.ensureIndex('research-profiles', 'research-profile', require('./vivo.json'));
+    await this.ensureIndex('research-profiles', null, require('./vivo.json'));
   }
 
   /**
@@ -103,7 +103,7 @@ class ElasticSearch {
    * @returns {Promise} resolves to string, new index name
    */
   async createIndex(alias, newIndexName) {
-    newIndexName = newIndexName || `${alias}-${Date.now()}`;
+    newIndexName = newIndexName && alias !== newIndexName ? newIndexName : `${alias}-${Date.now()}`;
     let vivo = JSON.parse(fs.readFileSync(path.join(__dirname, 'vivo.json'), 'utf-8'));
 
 

--- a/es-indexer/lib/elastic-search/vivo.json
+++ b/es-indexer/lib/elastic-search/vivo.json
@@ -37,6 +37,22 @@
       "type" : "text"
     },
 
+    "lastCitation.publication" : {
+      "type" : "text"
+    },
+
+    "lastCitation.label" : {
+      "type" : "text"
+    },
+
+    "top20Citation.publication" : {
+      "type" : "text"
+    },
+
+    "top20Citation.label" : {
+      "type" : "text"
+    },
+
     "Authorship.identifiers.@id" : {
       "type" : "keyword"
     },

--- a/es-indexer/lib/elastic-search/vivo.json
+++ b/es-indexer/lib/elastic-search/vivo.json
@@ -1,6 +1,29 @@
 {
   "dynamic" : false,
 
+  "dynamic_templates": [
+    {
+      "labels": {
+        "match_mapping_type": "string",
+        "match":   "*Label",
+        "mapping": {
+          "type" : "keyword",
+          "fields": {
+            "text" : {
+              "type" : "text",
+              "analyzer": "autocomplete", 
+              "search_analyzer": "autocomplete_search"
+            },
+            "firstLetter" : {
+              "type" : "keyword",
+              "normalizer": "first_letter_normilizer"
+            }
+          }
+        }
+      }
+    }
+  ],
+
   "properties" : {
 
     "@id" : {
@@ -13,6 +36,11 @@
 
     "@type" : {
       "type" : "keyword"
+    },
+
+    "_" : {
+      "type" : "object",
+      "dynamic" : true
     },
 
     "abstract" : {
@@ -45,11 +73,11 @@
       "type" : "text"
     },
 
-    "top20Citation.publication" : {
+    "_.top20Citation.publication" : {
       "type" : "text"
     },
 
-    "top20Citation.label" : {
+    "_.top20Citation.label" : {
       "type" : "text"
     },
 

--- a/es-indexer/lib/elastic-search/vivo.json
+++ b/es-indexer/lib/elastic-search/vivo.json
@@ -29,6 +29,14 @@
       "type" : "keyword"
     },
 
+    "citation.publication" : {
+      "type" : "text"
+    },
+
+    "citation.label" : {
+      "type" : "text"
+    },
+
     "Authorship.identifiers.@id" : {
       "type" : "keyword"
     },

--- a/es-indexer/lib/elastic-search/vivo.json
+++ b/es-indexer/lib/elastic-search/vivo.json
@@ -74,7 +74,7 @@
       }
     },
 
-    "hasSubjectArea.label" : {
+    "hasResearchArea.label" : {
       "type" : "keyword",
       "fields": {
         "text" : {
@@ -89,7 +89,7 @@
       "type" : "keyword"
     },
 
-    "Journal.label" : {
+    "hasPublicationVenue.label" : {
       "type" : "keyword",
       "fields": {
         "text" : {
@@ -100,7 +100,7 @@
       }
     },
 
-    "Journal.issn" : {
+    "hasPublicationVenue.issn" : {
       "type" : "keyword",
       "fields": {
         "text" : {

--- a/es-indexer/lib/elastic-search/vivo.json
+++ b/es-indexer/lib/elastic-search/vivo.json
@@ -127,7 +127,9 @@
     },
 
 
-
+    "_.allSubjectArea" : {
+      "type" : "keyword"
+    },
     "hasSubjectArea.@id" : {
       "type" : "keyword"
     },
@@ -138,6 +140,9 @@
       "type" : "keyword"
     },
 
+    "_.allResearchArea" : {
+      "type" : "keyword"
+    },
     "hasResearchArea.@id" : {
       "type" : "keyword"
     },

--- a/es-indexer/lib/elastic-search/vivo.json
+++ b/es-indexer/lib/elastic-search/vivo.json
@@ -98,15 +98,26 @@
       }
     },
 
+
+
+    "hasSubjectArea.@id" : {
+      "type" : "keyword"
+    },
+    "hasSubjectArea.label" : {
+      "type" : "keyword"
+    },
+    "hasSubjectArea.prefLabel" : {
+      "type" : "keyword"
+    },
+
+    "hasResearchArea.@id" : {
+      "type" : "keyword"
+    },
     "hasResearchArea.label" : {
-      "type" : "keyword",
-      "fields": {
-        "text" : {
-          "type" : "text",
-          "analyzer": "autocomplete", 
-          "search_analyzer": "autocomplete_search"
-        }
-      }
+      "type" : "keyword"
+    },
+    "hasResearchArea.prefLabel" : {
+      "type" : "keyword"
     },
 
     "issue" : {
@@ -150,6 +161,21 @@
       }
     },
 
+    "prefLabel" : {
+      "type" : "keyword",
+      "fields": {
+        "text" : {
+          "type" : "text",
+          "analyzer": "autocomplete", 
+          "search_analyzer": "autocomplete_search"
+        },
+        "firstLetter" : {
+          "type" : "keyword",
+          "normalizer": "first_letter_normilizer"
+        }
+      }
+    },
+
     "pageEnd" : {
       "type" : "integer"
     },
@@ -164,8 +190,55 @@
 
     "volume" : {
       "type" : "keyword"
-    }
+    },
 
+    "broader.@id" : {
+      "type" : "keyword"
+    },
+    "broader.label" : {
+      "type" : "keyword",
+      "fields": {
+        "text" : {
+          "type" : "text",
+          "analyzer": "autocomplete", 
+          "search_analyzer": "autocomplete_search"
+        }
+      }
+    },
+    "broader.prefLabel" : {
+      "type" : "keyword",
+      "fields": {
+        "text" : {
+          "type" : "text",
+          "analyzer": "autocomplete", 
+          "search_analyzer": "autocomplete_search"
+        }
+      }
+    },
+
+    "narrower.@id" : {
+      "type" : "keyword"
+    },
+    "narrower.label" : {
+      "type" : "keyword",
+      "fields": {
+        "text" : {
+          "type" : "text",
+          "analyzer": "autocomplete", 
+          "search_analyzer": "autocomplete_search"
+        }
+      }
+    },
+    "narrower.prefLabel" : {
+      "type" : "keyword",
+      "fields": {
+        "text" : {
+          "type" : "text",
+          "analyzer": "autocomplete", 
+          "search_analyzer": "autocomplete_search"
+        }
+      }
+    }
 
   }
 }

--- a/es-indexer/lib/elastic-search/vivo.json
+++ b/es-indexer/lib/elastic-search/vivo.json
@@ -118,6 +118,10 @@
           "type" : "text",
           "analyzer": "autocomplete", 
           "search_analyzer": "autocomplete_search"
+        },
+        "firstLetter" : {
+          "type" : "keyword",
+          "normalizer": "first_letter_normilizer"
         }
       }
     },

--- a/es-indexer/lib/es-sparql-model/clean.js
+++ b/es-indexer/lib/es-sparql-model/clean.js
@@ -1,7 +1,7 @@
 // TODO: this is just bad.
 class CleanModel {
 
-  run(model) {
+  run(model, args) {
     if( model.pageStart ) model.pageStart = model.pageStart.replace(/\D*/g, '');
     if( model.pageEnd ) model.pageEnd = model.pageEnd.replace(/\D*/g, '');
 
@@ -9,13 +9,15 @@ class CleanModel {
     this.cleanObject(model, 'hasSubjectArea');
     this.cleanObject(model, 'Journal');
 
+    model._ = {};
+
     // author count
     if( model.citation ) {
       if( !Array.isArray(model.citation) ) {
         model.citation = [model.citation];
       }
-      model.top20Citation = [];
-      model.lastCitation = [];
+      model._.top20Citation = [];
+      model._.lastCitation = [];
       
       model.citation = model.citation.map(item => {
         item.authorsCount = asArray(item.authors).length;
@@ -26,12 +28,12 @@ class CleanModel {
         if( item.authorsCount && item.rank ) {
           // is person last author
           if( item.authorsCount === item.rank ) {
-            model.lastCitation.push(item);
+            model._.lastCitation.push(item);
           }
 
           // is person top 20% rank in citation
           if( item.rank / item.authorsCount <= .2 ) {
-            model.top20Citation.push(item);
+            model._.top20Citation.push(item);
           }
         }
 
@@ -40,6 +42,10 @@ class CleanModel {
       });
     }
 
+    // for individual label indexing.
+    if( model.label ) {
+      model._[dashToCamel(args.modelType || 'default')+'Label'] = model.label;
+    }
 
     return model;
   }
@@ -60,6 +66,10 @@ class CleanModel {
     }
   }
 
+}
+
+function dashToCamel(str) {
+  return str.replace(/-([a-z])/g, g => g[1].toUpperCase());
 }
 
 function asArray(val) {

--- a/es-indexer/lib/es-sparql-model/clean.js
+++ b/es-indexer/lib/es-sparql-model/clean.js
@@ -9,6 +9,38 @@ class CleanModel {
     this.cleanObject(model, 'hasSubjectArea');
     this.cleanObject(model, 'Journal');
 
+    // author count
+    if( model.citation ) {
+      if( !Array.isArray(model.citation) ) {
+        model.citation = [model.citation];
+      }
+      model.top20Citation = [];
+      model.lastCitation = [];
+      
+      model.citation = model.citation.map(item => {
+        item.authorsCount = asArray(item.authors).length;
+
+        let author = asArray(item.authors).find(author => asArray(author.identifiers).includes(model['@id']));
+        if( author ) item.rank = author['vivo:rank'];
+
+        if( item.authorsCount && item.rank ) {
+          // is person last author
+          if( item.authorsCount === item.rank ) {
+            model.lastCitation.push(item);
+          }
+
+          // is person top 20% rank in citation
+          if( item.rank / item.authorsCount <= .2 ) {
+            model.top20Citation.push(item);
+          }
+        }
+
+        delete item.authors;
+        return item;
+      });
+    }
+
+
     return model;
   }
 
@@ -28,6 +60,12 @@ class CleanModel {
     }
   }
 
+}
+
+function asArray(val) {
+  if( !val ) return [];
+  if( !Array.isArray(val) ) return [val];
+  return val;
 }
 
 module.exports = new CleanModel();

--- a/es-indexer/lib/es-sparql-model/default-queries/map.js
+++ b/es-indexer/lib/es-sparql-model/default-queries/map.js
@@ -1,6 +1,13 @@
 module.exports = {
   // https://wiki.lyrasis.org/display/VIVODOC110x/Person+Model
-  person : ['http://xmlns.com/foaf/0.1/Person', 'http://vivoweb.org/ontology/core#NonAcademic','http://vivoweb.org/ontology/core#FacultyMember'],
+  person : {
+    types : ['http://xmlns.com/foaf/0.1/Person', 'http://vivoweb.org/ontology/core#NonAcademic','http://vivoweb.org/ontology/core#FacultyMember'],
+    additionalProperties : {
+      citation : 'person-citations'
+    }
+  },
+
+  'subject-area' : ['http://www.w3.org/2004/02/skos/core#Concept'],
 
   // https://wiki.lyrasis.org/display/VIVODOC110x/Publication+Model
   publication : ['http://purl.org/ontology/bibo/AcademicArticle','http://purl.org/ontology/bibo/Book','http://purl.org/ontology/bibo/Chapter','http://vivoweb.org/ontology/core#ConferencePaper'],

--- a/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
@@ -47,50 +47,48 @@ CONSTRUCT {
   ?vcardAddress vcard:country ?country .
 
 } WHERE {
-  GRAPH "{{graph}}" {
-    ?subject rdf:type ?type .
+  ?subject rdf:type ?type .
 
-    OPTIONAL { ?subject rdfs:label ?label . }
-    OPTIONAL { ?subject vivo:abbreviation ?abbreviation . }
-    OPTIONAL { ?subject vivo:overview ?overview . }
+  OPTIONAL { ?subject rdfs:label ?label . }
+  OPTIONAL { ?subject vivo:abbreviation ?abbreviation . }
+  OPTIONAL { ?subject vivo:overview ?overview . }
 
-    OPTIONAL {
-      ?subject vivo:dateTimeValue ?dateTimeValue .
-      ?dateTimeValue vivo:dateTime ?dateTime .
-    }
-
-    OPTIONAL { ?subject obo:BFO_0000050 ?partOfOrg . }
-    OPTIONAL { ?hasPartOrg obo:BFO_0000051 ?subject . }
-
-    OPTIONAL { ?subject vivo:hasSuccessorOrganization ?hasSuccessorOrganization . }
-    OPTIONAL { ?hasPredecessorOrganization vivo:hasPredecessorOrganization ?subject . }
-
-    OPTIONAL { ?subject vivo:affiliatedOrganization ?affiliatedOrganization . }
-
-    OPTIONAL {
-      ?subject obo:ARG_2000028 ?contactInfoFor .
-
-      OPTIONAL { ?contactInfoFor vcard:hasEmail ?vcardEmail . }
-      OPTIONAL { ?vcardEmail vcard:email ?email . }
-      OPTIONAL { ?vcardEmail rdf:type ?emailType . }
-
-      OPTIONAL { ?contactInfoFor vcard:hasGeo ?vcardGeo . }
-      OPTIONAL { ?vcardGeo vcard:geo ?geo . }
-
-      OPTIONAL { ?contactInfoFor vcard:hasURL ?vcardURL . }
-      OPTIONAL { ?vcardURL vcard:url ?url . }
-      OPTIONAL { ?vcardURL vcard:rank ?urlRank . }
-      OPTIONAL { ?vcardURL vcard:label ?urlLabel . }
-
-      OPTIONAL { ?contactInfoFor vcard:hasAddress ?vcardAddress . }
-      OPTIONAL { ?vcardAddress vcard:locality ?locality . }
-      OPTIONAL { ?vcardAddress vcard:postalCode ?postalCode . }
-      OPTIONAL { ?vcardAddress vcard:streetAddress ?streetAddress . }
-      OPTIONAL { ?vcardAddress vcard:region ?region . }
-      OPTIONAL { ?vcardAddress vcard:country ?country . }
-    }
-
-
-    FILTER(?subject = "{{uri}}")
+  OPTIONAL {
+    ?subject vivo:dateTimeValue ?dateTimeValue .
+    ?dateTimeValue vivo:dateTime ?dateTime .
   }
+
+  OPTIONAL { ?subject obo:BFO_0000050 ?partOfOrg . }
+  OPTIONAL { ?hasPartOrg obo:BFO_0000051 ?subject . }
+
+  OPTIONAL { ?subject vivo:hasSuccessorOrganization ?hasSuccessorOrganization . }
+  OPTIONAL { ?hasPredecessorOrganization vivo:hasPredecessorOrganization ?subject . }
+
+  OPTIONAL { ?subject vivo:affiliatedOrganization ?affiliatedOrganization . }
+
+  OPTIONAL {
+    ?subject obo:ARG_2000028 ?contactInfoFor .
+
+    OPTIONAL { ?contactInfoFor vcard:hasEmail ?vcardEmail . }
+    OPTIONAL { ?vcardEmail vcard:email ?email . }
+    OPTIONAL { ?vcardEmail rdf:type ?emailType . }
+
+    OPTIONAL { ?contactInfoFor vcard:hasGeo ?vcardGeo . }
+    OPTIONAL { ?vcardGeo vcard:geo ?geo . }
+
+    OPTIONAL { ?contactInfoFor vcard:hasURL ?vcardURL . }
+    OPTIONAL { ?vcardURL vcard:url ?url . }
+    OPTIONAL { ?vcardURL vcard:rank ?urlRank . }
+    OPTIONAL { ?vcardURL vcard:label ?urlLabel . }
+
+    OPTIONAL { ?contactInfoFor vcard:hasAddress ?vcardAddress . }
+    OPTIONAL { ?vcardAddress vcard:locality ?locality . }
+    OPTIONAL { ?vcardAddress vcard:postalCode ?postalCode . }
+    OPTIONAL { ?vcardAddress vcard:streetAddress ?streetAddress . }
+    OPTIONAL { ?vcardAddress vcard:region ?region . }
+    OPTIONAL { ?vcardAddress vcard:country ?country . }
+  }
+
+
+  FILTER(?subject = "{{uri}}")
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
@@ -91,6 +91,6 @@ CONSTRUCT {
     }
 
 
-    FILTER(?subject = <"{{uri}}">)
+    FILTER(?subject = "{{uri}}")
   }
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
@@ -7,7 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 
 CONSTRUCT {
   ?subject rdf:type ?type .

--- a/es-indexer/lib/es-sparql-model/default-queries/person-citations.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person-citations.tpl.rq
@@ -7,8 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucd: <http://experts.ucdavis.edu/schema#>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 
 CONSTRUCT {
   ?subject rdf:type ?type .
@@ -52,6 +51,6 @@ CONSTRUCT {
   }
 
   FILTER(
-    ?subject = "{{uri}}" && 
+    ?subject = "{{uri}}" &&
     ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/person-citations.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person-citations.tpl.rq
@@ -1,0 +1,57 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX bibo: <http://purl.org/ontology/bibo/>
+PREFIX vivo: <http://vivoweb.org/ontology/core#>
+PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ucd: <http://experts.ucdavis.edu/schema#>
+PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+
+CONSTRUCT {
+  ?subject rdf:type ?type .
+  ?subject rdf:type ucdrp:person .
+
+  ?subject ucdrp:citation ?citation .
+  ?citation rdfs:label ?citationLabel .
+  ?citation ucdrp:publication ?citationPublicationVenueLabel .
+
+  ?citation ucdrp:authors ?citationAuthors .
+  ?citationAuthors vivo:rank ?citationAuthorRank .
+  ?citationAuthors vivo:identifiers  ?authorPerson .
+} WHERE {
+
+  ?subject rdf:type ?type .
+
+  OPTIONAL {
+    ?citation rdf:type bibo:AcademicArticle .
+    ?citation rdfs:label ?citationLabel .
+    ?citation vivo:relatedBy ?citationAuthor .
+    ?citationAuthor vivo:relates ?subject .
+
+    OPTIONAL {
+      ?citation vivo:relatedBy ?citationAuthors .
+      ?citationAuthors rdf:type vivo:Authorship .
+
+      OPTIONAL {
+        ?citationAuthors vivo:rank ?citationAuthorRank .
+      }
+
+      OPTIONAL {
+        ?citationAuthors vivo:relates ?authorPerson .
+        ?authorPerson rdf:type ?authorPersonType .
+      }
+
+    }
+    OPTIONAL {
+      ?citation vivo:hasPublicationVenue ?citationPublicationVenue .
+      ?citationPublicationVenue rdfs:label ?citationPublicationVenueLabel .
+    }
+  }
+
+  FILTER(
+    ?subject = "{{uri}}" && 
+    ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
+}

--- a/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
@@ -7,8 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucd: <http://experts.ucdavis.edu/schema#>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX free: <http://experts.ucdavis.edu/sub/free#>
 PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>
@@ -23,7 +22,7 @@ CONSTRUCT {
   ?subject vivo:eRACommonsId ?eRACommonsId .
   ?subject vivo:overview ?overview .
 
-  ?subject ucd:casId ?casId .
+  ?subject ucdrp:casId ?casId .
 
   ?subject vivo:orcidId ?orcidId .
   ?orcidId vivo:confirmedOrcidId ?confirmedOrcidId .
@@ -48,7 +47,7 @@ CONSTRUCT {
   ?contactInfoFor vcard:telephone ?telephone .
   ?contactInfoFor vcard:geo ?geo .
   ?contactInfoFor vivo:rank ?vcardRank .
-  ?contactInfoFor ucd:identifier ?identifier .
+  ?contactInfoFor ucdrp:identifier ?identifier .
 
   ?contactInfoFor vcard:hasURL ?vcardURL .
   ?vcardURL vcard:url ?url .
@@ -74,7 +73,7 @@ CONSTRUCT {
     OPTIONAL { ?subject vivo:eRACommonsId ?eRACommonsId . }
     OPTIONAL { ?subject vivo:overview ?overview . }
 
-    OPTIONAL { ?subject ucd:casId ?casId . }
+    OPTIONAL { ?subject ucdrp:casId ?casId . }
 
     OPTIONAL {
       ?subject vivo:orcidId ?orcidId .
@@ -100,7 +99,7 @@ CONSTRUCT {
       }
 
       OPTIONAL { ?contactInfoFor vivo:rank ?vcardRank . }
-      OPTIONAL { ?contactInfoFor ucd:identifier ?identifier . }
+      OPTIONAL { ?contactInfoFor ucdrp:identifier ?identifier . }
 
       OPTIONAL {
         ?contactInfoFor vcard:hasEmail ?vcardEmail .

--- a/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
@@ -64,6 +64,15 @@ CONSTRUCT {
   ?subject ucdrp:citation ?citation .
   ?citation rdfs:label ?citationLabel .
   ?citation ucdrp:publication ?citationPublicationVenueLabel .
+  # ?citation vivo:rank ?citationAuthorRank .
+
+  ?citation ucdrp:authors ?citationAuthors .
+  ?citationAuthors vivo:rank ?citationAuthorRank .
+  # ?citationAuthors vivo:identifiers ?citationAuthorIdentifier .
+  # ?citationsAuthor vivo:rank ?citationAuthorsRank .
+
+  ?citationAuthors vivo:identifiers  ?authorPerson .
+
   # ?citation rdf:type vivo:Authorship .
   # ?citation vivo:rank ?citationAuthorRank .
   # ?citation vivo:hasPublicationVenue ?citationPublicationVenue .
@@ -178,9 +187,23 @@ CONSTRUCT {
       ?citation vivo:relatedBy ?citationAuthor .
       ?citationAuthor vivo:relates ?subject .
       # OPTIONAL { ?citationAuthor vivo:rank ?citationAuthorRank . }
+      # OPTIONAL {
+      #   ?citationAuthor vivo:relates ?authorIndividual .
+      #   ?authorIndividual rdf:type vcard:Individual .
+      # }
       OPTIONAL {
-        ?citationAuthor vivo:relates ?authorIndividual .
-        ?authorIndividual rdf:type vcard:Individual .
+        ?citation vivo:relatedBy ?citationAuthors .
+        ?citationAuthors rdf:type vivo:Authorship .
+
+        OPTIONAL {
+          ?citationAuthors vivo:rank ?citationAuthorRank .
+        }
+
+        OPTIONAL {
+          ?citationAuthors vivo:relates ?authorPerson .
+          ?authorPerson rdf:type ?authorPersonType .
+        }
+
       }
       OPTIONAL {
         ?citation vivo:hasPublicationVenue ?citationPublicationVenue .
@@ -190,6 +213,8 @@ CONSTRUCT {
       }
     }
 
-    FILTER(?subject = <"{{uri}}">)
+    FILTER(
+      ?subject = "{{uri}}" && 
+      ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
   }
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
@@ -9,6 +9,9 @@ PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX ucd: <http://experts.ucdavis.edu/schema#>
 PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX free: <http://experts.ucdavis.edu/sub/free#>
+PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>
 
 CONSTRUCT {
   ?subject rdf:type ?type .
@@ -26,7 +29,8 @@ CONSTRUCT {
   ?orcidId vivo:confirmedOrcidId ?confirmedOrcidId .
 
   ?subject vivo:hasResearchArea ?hasResearchArea .
-  ?hasResearchArea rdfs:label ?researchAreaLabel .
+  ?hasResearchArea rdfs:label ?hasResearchAreaLabel .
+  ?hasResearchArea skos:prefLabel ?hasResearchAreaPrefLabel .
 
   ?subject obo:hasContactInfo ?contactInfoFor .
   ?contactInfoFor vcard:givenName ?givenName .
@@ -61,27 +65,7 @@ CONSTRUCT {
   ?positionOrg rdfs:start ?positionStartTimeValue .
   ?positionOrg rdfs:end ?positionEndTimeValue .
 
-  ?subject ucdrp:citation ?citation .
-  ?citation rdfs:label ?citationLabel .
-  ?citation ucdrp:publication ?citationPublicationVenueLabel .
-  # ?citation vivo:rank ?citationAuthorRank .
-
-  ?citation ucdrp:authors ?citationAuthors .
-  ?citationAuthors vivo:rank ?citationAuthorRank .
-  # ?citationAuthors vivo:identifiers ?citationAuthorIdentifier .
-  # ?citationsAuthor vivo:rank ?citationAuthorsRank .
-
-  ?citationAuthors vivo:identifiers  ?authorPerson .
-
-  # ?citation rdf:type vivo:Authorship .
-  # ?citation vivo:rank ?citationAuthorRank .
-  # ?citation vivo:hasPublicationVenue ?citationPublicationVenue .
-  # ?citationPublicationVenue rdf:type ?citationPublicationVenueType .
-  # ?citationPublicationVenue rdfs:label ?citationPublicationVenueLabel .
-  # ?citationPublicationVenue bibo:issn ?citationPublicationVenueIssn .
-
 } WHERE {
-  GRAPH "{{graph}}" {
 
     ?subject rdf:type ?type .
     OPTIONAL { ?subject rdfs:label ?label . }
@@ -99,7 +83,8 @@ CONSTRUCT {
 
     OPTIONAL {
       ?subject vivo:hasResearchArea ?hasResearchArea .
-      ?hasResearchArea rdfs:label ?researchAreaLabel .
+      ?hasResearchArea rdfs:label ?hasResearchAreaLabel .
+      OPTIONAL { ?hasResearchArea skos:prefLabel ?hasResearchAreaPrefLabel . }
     }
 
     OPTIONAL {
@@ -181,40 +166,5 @@ CONSTRUCT {
       }
     }
 
-    OPTIONAL {
-      ?citation rdf:type bibo:AcademicArticle .
-      ?citation rdfs:label ?citationLabel .
-      ?citation vivo:relatedBy ?citationAuthor .
-      ?citationAuthor vivo:relates ?subject .
-      # OPTIONAL { ?citationAuthor vivo:rank ?citationAuthorRank . }
-      # OPTIONAL {
-      #   ?citationAuthor vivo:relates ?authorIndividual .
-      #   ?authorIndividual rdf:type vcard:Individual .
-      # }
-      OPTIONAL {
-        ?citation vivo:relatedBy ?citationAuthors .
-        ?citationAuthors rdf:type vivo:Authorship .
-
-        OPTIONAL {
-          ?citationAuthors vivo:rank ?citationAuthorRank .
-        }
-
-        OPTIONAL {
-          ?citationAuthors vivo:relates ?authorPerson .
-          ?authorPerson rdf:type ?authorPersonType .
-        }
-
-      }
-      OPTIONAL {
-        ?citation vivo:hasPublicationVenue ?citationPublicationVenue .
-        ?citationPublicationVenue rdfs:label ?citationPublicationVenueLabel .
-        # ?citationPublicationVenue rdf:type ?citationPublicationVenueType .
-        # ?citationPublicationVenue bibo:issn ?citationPublicationVenueIssn .
-      }
-    }
-
-    FILTER(
-      ?subject = "{{uri}}" && 
-      ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
-  }
+    FILTER( ?subject = "{{uri}}" )
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
@@ -61,6 +61,16 @@ CONSTRUCT {
   ?positionOrg rdfs:start ?positionStartTimeValue .
   ?positionOrg rdfs:end ?positionEndTimeValue .
 
+  ?subject ucdrp:citation ?citation .
+  ?citation rdfs:label ?citationLabel .
+  ?citation ucdrp:publication ?citationPublicationVenueLabel .
+  # ?citation rdf:type vivo:Authorship .
+  # ?citation vivo:rank ?citationAuthorRank .
+  # ?citation vivo:hasPublicationVenue ?citationPublicationVenue .
+  # ?citationPublicationVenue rdf:type ?citationPublicationVenueType .
+  # ?citationPublicationVenue rdfs:label ?citationPublicationVenueLabel .
+  # ?citationPublicationVenue bibo:issn ?citationPublicationVenueIssn .
+
 } WHERE {
   GRAPH "{{graph}}" {
 
@@ -160,7 +170,24 @@ CONSTRUCT {
         ?positionDateTime vivo:end ?positionEndTime .
         ?positionEndTime rdfs:label ?positionEndTimeValue .
       }
+    }
 
+    OPTIONAL {
+      ?citation rdf:type bibo:AcademicArticle .
+      ?citation rdfs:label ?citationLabel .
+      ?citation vivo:relatedBy ?citationAuthor .
+      ?citationAuthor vivo:relates ?subject .
+      # OPTIONAL { ?citationAuthor vivo:rank ?citationAuthorRank . }
+      OPTIONAL {
+        ?citationAuthor vivo:relates ?authorIndividual .
+        ?authorIndividual rdf:type vcard:Individual .
+      }
+      OPTIONAL {
+        ?citation vivo:hasPublicationVenue ?citationPublicationVenue .
+        ?citationPublicationVenue rdfs:label ?citationPublicationVenueLabel .
+        # ?citationPublicationVenue rdf:type ?citationPublicationVenueType .
+        # ?citationPublicationVenue bibo:issn ?citationPublicationVenueIssn .
+      }
     }
 
     FILTER(?subject = <"{{uri}}">)

--- a/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
@@ -43,7 +43,7 @@ CONSTRUCT {
   ?subject vivo:hasSubjectArea ?subjectArea .
   ?subjectArea rdfs:label ?subjectAreaLabel .
 
-  ?subject bibo:Journal ?publicationVenue .
+  ?subject vivo:hasPublicationVenue ?publicationVenue .
   ?publicationVenue rdfs:label ?publicationVenueLabel .
   ?publicationVenue bibo:issn ?publicationVenueIssn .
 

--- a/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
@@ -110,6 +110,6 @@ CONSTRUCT {
       OPTIONAL { ?publicationDate vivo:dateTime ?dateTime . }
     }
 
-    FILTER(?subject = <"{{uri}}"> && ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
+    FILTER(?subject = "{{uri}}" && ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
   }
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
@@ -7,7 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX free: <http://experts.ucdavis.edu/sub/free#>
 PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>

--- a/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
@@ -8,6 +8,9 @@ PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX free: <http://experts.ucdavis.edu/sub/free#>
+PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>
 
 CONSTRUCT {
   ?subject rdf:type ?type .
@@ -41,6 +44,7 @@ CONSTRUCT {
 
   ?subject vivo:hasSubjectArea ?subjectArea .
   ?subjectArea rdfs:label ?subjectAreaLabel .
+  ?subjectArea skos:prefLabel ?subjectAreaPrefLabel .
 
   ?subject vivo:hasPublicationVenue ?publicationVenue .
   ?publicationVenue rdfs:label ?publicationVenueLabel .
@@ -50,66 +54,65 @@ CONSTRUCT {
   ?supportedBy rdfs:label ?supportedByLabel .
 
 } WHERE {
-  GRAPH "{{graph}}" {
 
-    ?subject rdf:type ?type .
-    OPTIONAL { ?subject rdfs:label ?label . }
-    OPTIONAL { ?subject bibo:abstract ?abstract . }
-    OPTIONAL { ?subject bibo:doi ?doi . }
-    OPTIONAL { ?subject bibo:volume ?volume . }
-    OPTIONAL { ?subject bibo:pageStart ?pageStart . }
-    OPTIONAL { ?subject bibo:pageEnd ?pageEnd . }
+  ?subject rdf:type ?type .
+  OPTIONAL { ?subject rdfs:label ?label . }
+  OPTIONAL { ?subject bibo:abstract ?abstract . }
+  OPTIONAL { ?subject bibo:doi ?doi . }
+  OPTIONAL { ?subject bibo:volume ?volume . }
+  OPTIONAL { ?subject bibo:pageStart ?pageStart . }
+  OPTIONAL { ?subject bibo:pageEnd ?pageEnd . }
 
+  OPTIONAL {
+    ?subject vivo:relatedBy ?author .
+    ?author rdf:type vivo:Authorship .
+    OPTIONAL { ?author vivo:rank ?authorRank . }
     OPTIONAL {
-      ?subject vivo:relatedBy ?author .
-      ?author rdf:type vivo:Authorship .
-      OPTIONAL { ?author vivo:rank ?authorRank . }
-      OPTIONAL {
-        ?author vivo:relates ?authorIndividual .
-        ?authorIndividual rdf:type vcard:Individual .
-        ?authorIndividual vcard:hasName ?authorVcardName .
-        OPTIONAL { ?authorVcardName vcard:givenName ?authorGivenName . }
-        OPTIONAL { ?authorVcardName vcard:middleName ?authorMiddleName . }
-        OPTIONAL { ?authorVcardName vcard:familyName ?authorFamilyName . }
-      }
-      OPTIONAL{
-        ?author vivo:relates ?authorPerson .
-        ?authorPerson rdf:type ?authorPersonType .
-        OPTIONAL { ?authorPerson vivo:orcidid ?authorOrcid . }
-        # OPTIONAL { ?authorPerson rdfs:label ?authorLabel . }
-      }
+      ?author vivo:relates ?authorIndividual .
+      ?authorIndividual rdf:type vcard:Individual .
+      ?authorIndividual vcard:hasName ?authorVcardName .
+      OPTIONAL { ?authorVcardName vcard:givenName ?authorGivenName . }
+      OPTIONAL { ?authorVcardName vcard:middleName ?authorMiddleName . }
+      OPTIONAL { ?authorVcardName vcard:familyName ?authorFamilyName . }
     }
-
-    OPTIONAL {
-      ?subject obo:ARG_2000028 ?hasContactInfo .
-      ?hasContactInfo vcard:hasURL ?contactInfoHasUrl .
-      OPTIONAL { ?contactInfoHasUrl vcard:url ?contactInfoUrl . }
-      OPTIONAL { ?contactInfoHasUrl vivo:rank ?contactInfoRank . }
-      OPTIONAL { ?contactInfoHasUrl rdfs:label ?contactInfoLabel . }
+    OPTIONAL{
+      ?author vivo:relates ?authorPerson .
+      ?authorPerson rdf:type ?authorPersonType .
+      OPTIONAL { ?authorPerson vivo:orcidid ?authorOrcid . }
+      # OPTIONAL { ?authorPerson rdfs:label ?authorLabel . }
     }
-
-    OPTIONAL {
-      ?subject vivo:hasSubjectArea ?subjectArea .
-      ?subjectArea rdfs:label ?subjectAreaLabel .
-      ?subjectArea rdf:type ?subjectAreaType .
-    }
-
-    OPTIONAL {
-      ?subject vivo:hasPublicationVenue ?publicationVenue .
-      ?publicationVenue rdf:type ?publicationVenueType .
-      ?publicationVenue bibo:issn ?publicationVenueIssn .
-    }
-
-    OPTIONAL {
-      ?subject vivo:informationResourceSupportedBy ?supportedBy .
-      ?supportedBy rdfs:label ?supportedByLabel .
-    }
-
-    OPTIONAL {
-      ?subject vivo:dateTimeValue ?publicationDate .
-      OPTIONAL { ?publicationDate vivo:dateTime ?dateTime . }
-    }
-
-    FILTER(?subject = "{{uri}}" && ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
   }
+
+  OPTIONAL {
+    ?subject obo:ARG_2000028 ?hasContactInfo .
+    ?hasContactInfo vcard:hasURL ?contactInfoHasUrl .
+    OPTIONAL { ?contactInfoHasUrl vcard:url ?contactInfoUrl . }
+    OPTIONAL { ?contactInfoHasUrl vivo:rank ?contactInfoRank . }
+    OPTIONAL { ?contactInfoHasUrl rdfs:label ?contactInfoLabel . }
+  }
+
+  OPTIONAL {
+    ?subject vivo:hasSubjectArea ?subjectArea .
+    ?subjectArea rdfs:label ?subjectAreaLabel .
+    OPTIONAL { ?subjectArea skos:prefLabel ?subjectAreaPrefLabel . }
+  }
+
+  OPTIONAL {
+    ?subject vivo:hasPublicationVenue ?publicationVenue .
+    ?publicationVenue rdf:type ?publicationVenueType .
+    ?publicationVenue bibo:issn ?publicationVenueIssn .
+  }
+
+  OPTIONAL {
+    ?subject vivo:informationResourceSupportedBy ?supportedBy .
+    ?supportedBy rdfs:label ?supportedByLabel .
+  }
+
+  OPTIONAL {
+    ?subject vivo:dateTimeValue ?publicationDate .
+    OPTIONAL { ?publicationDate vivo:dateTime ?dateTime . }
+  }
+
+  FILTER(?subject = "{{uri}}" && ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
+
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/subject-area.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/subject-area.tpl.rq
@@ -7,8 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucd: <http://experts.ucdavis.edu/schema#>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX free: <http://experts.ucdavis.edu/sub/free#>
 PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>
@@ -25,7 +24,7 @@ CONSTRUCT {
   ?subject skos:broader ?broader .
   ?broader rdfs:label ?broaderLabel .
   ?broader skos:prefLabel ?broaderPrefLabel .
-  
+
   ?subject skos:narrower ?narrower .
   ?narrower rdfs:label ?narrowerLabel .
   ?narrower skos:prefLabel ?narrowerPrefLabel .
@@ -38,13 +37,13 @@ CONSTRUCT {
   OPTIONAL { ?subject skos:prefLabel ?prefLabel . }
 
   OPTIONAL { ?subject skos:inSchema ?inSchema .  }
-  OPTIONAL { 
-    ?subject skos:broader ?broader . 
+  OPTIONAL {
+    ?subject skos:broader ?broader .
     ?broader rdfs:label ?broaderLabel .
     OPTIONAL { ?broader skos:prefLabel ?broaderPrefLabel . }
   }
-  OPTIONAL { 
-    ?subject skos:narrower ?narrower . 
+  OPTIONAL {
+    ?subject skos:narrower ?narrower .
     ?narrower rdfs:label ?narrowerLabel .
     OPTIONAL { ?narrower skos:prefLabel ?narrowerPrefLabel . }
   }

--- a/es-indexer/lib/es-sparql-model/default-queries/subject-area.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/subject-area.tpl.rq
@@ -1,0 +1,54 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX bibo: <http://purl.org/ontology/bibo/>
+PREFIX vivo: <http://vivoweb.org/ontology/core#>
+PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX ucd: <http://experts.ucdavis.edu/schema#>
+PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX free: <http://experts.ucdavis.edu/sub/free#>
+PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>
+
+CONSTRUCT {
+  ?subject rdf:type ?type .
+  ?subject rdf:type ucdrp:subjectArea .
+
+  ?subject rdfs:label ?label .
+  ?subject skos:prefLabel ?prefLabel .
+
+  ?subject skos:inSchema ?inSchema .
+
+  ?subject skos:broader ?broader .
+  ?broader rdfs:label ?broaderLabel .
+  ?broader skos:prefLabel ?broaderPrefLabel .
+  
+  ?subject skos:narrower ?narrower .
+  ?narrower rdfs:label ?narrowerLabel .
+  ?narrower skos:prefLabel ?narrowerPrefLabel .
+
+} WHERE {
+
+  ?subject rdf:type ?type .
+
+  OPTIONAL { ?subject rdfs:label ?label . }
+  OPTIONAL { ?subject skos:prefLabel ?prefLabel . }
+
+  OPTIONAL { ?subject skos:inSchema ?inSchema .  }
+  OPTIONAL { 
+    ?subject skos:broader ?broader . 
+    ?broader rdfs:label ?broaderLabel .
+    OPTIONAL { ?broader skos:prefLabel ?broaderPrefLabel . }
+  }
+  OPTIONAL { 
+    ?subject skos:narrower ?narrower . 
+    ?narrower rdfs:label ?narrowerLabel .
+    OPTIONAL { ?narrower skos:prefLabel ?narrowerPrefLabel . }
+  }
+
+  FILTER( ?subject = "{{uri}}" )
+
+}

--- a/es-indexer/lib/es-sparql-model/index.js
+++ b/es-indexer/lib/es-sparql-model/index.js
@@ -1,5 +1,5 @@
 const {fuseki, config, logger} = require('@ucd-lib/rp-node-utils');
-const clean = require('./clean');
+const postProcess = require('./post-process');
 const path = require('path');
 const fs = require('fs');
 
@@ -133,7 +133,7 @@ class EsSparqlModel {
       result.model[prop] = propResult[prop];
     }
 
-    clean.run(result.model, {type, modelType: model});
+    await postProcess.run(result.model, {type, modelType: model});
     result.model.uri = uri;
     result.model.indexerTimestamp = Date.now();
 

--- a/es-indexer/lib/es-sparql-model/index.js
+++ b/es-indexer/lib/es-sparql-model/index.js
@@ -9,6 +9,7 @@ class EsSparqlModel {
 
   constructor() {
     this.GRAPHS = config.fuseki.graphs;
+    this.GRAPHS.push('http://experts.ucdavis.edu/oap/');
 
     this.TYPES = {};
     this.MODELS = {};
@@ -83,10 +84,13 @@ class EsSparqlModel {
     if( !graph.match(/^\?/) ) {
       graph = '<'+graph+'>';
     }
+    if( uri.match('http(s)?:\/\/') ) {
+      uri = '<'+uri+'>';
+    }
 
     return this.TEMPLATES[model]
-      .replace(/"{{uri}}"/, uri)
-      .replace(/"{{graph}}"/, graph);
+      .replace(/"{{uri}}"/g, uri)
+      .replace(/"{{graph}}"/g, graph);
   }
 
   /**
@@ -106,7 +110,7 @@ class EsSparqlModel {
     }
 
     let result = {
-      model : type,
+      type,
       database : config.fuseki.database,
       graphs : {},
       model : {}

--- a/es-indexer/lib/es-sparql-model/index.js
+++ b/es-indexer/lib/es-sparql-model/index.js
@@ -139,6 +139,9 @@ class EsSparqlModel {
   async _getModelForGraph(graph, type, uri) {
     let sparqlQuery = this.getSparqlQuery(type, uri, graph);
     let response = await fuseki.query(sparqlQuery, 'application/ld+json');
+
+    // let t = await response.text();
+    // response = JSON.parse(t);
     response = await response.json();
 
     // TODO: this is wrong

--- a/es-indexer/lib/es-sparql-model/index.js
+++ b/es-indexer/lib/es-sparql-model/index.js
@@ -133,7 +133,7 @@ class EsSparqlModel {
       result.model[prop] = propResult[prop];
     }
 
-    clean.run(result.model);
+    clean.run(result.model, {type, modelType: model});
     result.model.uri = uri;
     result.model.indexerTimestamp = Date.now();
 

--- a/es-indexer/lib/index-stats.js
+++ b/es-indexer/lib/index-stats.js
@@ -74,9 +74,6 @@ class IndexStats {
       });
     }
 
-    console.log(subjects);
-
-
     await this.kafkaConsumer.disconnect();
   }
 

--- a/es-indexer/lib/reindex.js
+++ b/es-indexer/lib/reindex.js
@@ -182,8 +182,16 @@ class Reindex {
     LIMIT ${count}
     OFFSET ${page*100}
     `);
-    response = await response.json();
-    return [...new Set(response.results.bindings.map(term => term.subject.value))];
+
+    try {
+      response = await response.text();
+      response = JSON.parse(response);
+      
+      return [...new Set(response.results.bindings.map(term => term.subject.value))];
+    } catch(e) {
+      logger.error('Failed: reindex.getSubjectsForType: '+type+', '+page,  'reponse=', response, e);
+    }
+    return [];
   }
 
 

--- a/es-indexer/package-lock.json
+++ b/es-indexer/package-lock.json
@@ -1,8 +1,487 @@
 {
   "name": "es-indexer",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "elasticsearch": "^16.7.1",
+        "express": "^4.17.1",
+        "n3": "^1.4.0",
+        "node-fetch": "^2.6.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "node_modules/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "node_modules/destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "node_modules/elasticsearch": {
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-16.7.1.tgz",
+      "integrity": "sha512-PL/BxB03VGbbghJwISYvVcrR9KbSSkuQ7OM//jHJg/End/uC2fvXg4QI7RXLvCGbhBuNQ8dPue7DOOPra73PCw==",
+      "dependencies": {
+        "agentkeepalive": "^3.4.1",
+        "chalk": "^1.0.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "node_modules/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "node_modules/mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dependencies": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/n3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.4.0.tgz",
+      "integrity": "sha512-aEo8Jc+ZM9GoBtt7/OW+7aczMh4wLdt1IUcT8JCgv/b+ko5PCvkR0793rzWdu7+wJmA93sNb/3yM+01i9pz6fA==",
+      "dependencies": {
+        "queue-microtask": "^1.1.2"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.3.tgz",
+      "integrity": "sha512-zC1ZDLKFhZSa8vAdFbkOGouHcOUMgUAI/2/3on/KktpY+BaVqABkzDSsCSvJfmLbICOnrEuF9VIMezZf+T0mBA=="
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  },
   "dependencies": {
     "accepts": {
       "version": "1.3.7",

--- a/node-utils/lib/config.js
+++ b/node-utils/lib/config.js
@@ -9,7 +9,7 @@ if( graphs ) {
   graphs = [
     'http://iam.ucdavis.edu/',
     'http://oapolicy.universityofcalifornia.edu/',
-    'http://experts.ucdavis.edu/oap/'
+    'http://experts.ucdavis.edu/'
   ]
 }
 

--- a/node-utils/lib/config.js
+++ b/node-utils/lib/config.js
@@ -94,7 +94,7 @@ module.exports = {
     requestTimeout : env.ELASTIC_SEARCH_REQUEST_TIME || 3*60*1000,
     indexAlias : 'research-profiles',
     fields : {
-      exclude : ['top20Citation', 'citation', 'lastCitation'],
+      exclude : ['_', 'citation'],
     }
   },
 

--- a/node-utils/lib/config.js
+++ b/node-utils/lib/config.js
@@ -65,8 +65,8 @@ module.exports = {
     database : env.FUSEKI_DATABASE || 'vivo',
     graphs,
     rootPrefix : {
-      uri : 'http://experts.library.ucdavis.edu/individual/',
-      prefix: 'ucdrp'
+      uri : 'http://experts.ucdavis.edu/',
+      prefix: 'experts'
     }
   },
 

--- a/node-utils/lib/config.js
+++ b/node-utils/lib/config.js
@@ -94,7 +94,7 @@ module.exports = {
     requestTimeout : env.ELASTIC_SEARCH_REQUEST_TIME || 3*60*1000,
     indexAlias : 'research-profiles',
     fields : {
-      exclude : []
+      exclude : ['top20Citation', 'citation', 'lastCitation'],
     }
   },
 

--- a/node-utils/lib/config.js
+++ b/node-utils/lib/config.js
@@ -8,7 +8,8 @@ if( graphs ) {
 } else {
   graphs = [
     'http://iam.ucdavis.edu/',
-    'http://oapolicy.universityofcalifornia.edu/'
+    'http://oapolicy.universityofcalifornia.edu/',
+    'http://experts.ucdavis.edu/oap/'
   ]
 }
 

--- a/node-utils/lib/kafka/Producer.js
+++ b/node-utils/lib/kafka/Producer.js
@@ -16,6 +16,7 @@ class Producer {
   connect(opts={}) {
     return new Promise((resolve, reject) => {
       this.client.connect(opts, (err, data) => {
+        this.client.setPollInterval(100);
         if( err ) reject(err);
         else resolve(data);
       });


### PR DESCRIPTION
This was my first try at the required updates for the new identifier standardizing for the version 2.0 of the experts system.  The main thrusts are :  1) base moves from `experts.library.ucdavis.edu/individual/` to `experts.ucdavis.edu/` and conflating together the `ucd:` and `ucdrp:` to a common schema.
