### PR TITLE
Updated for new expert identifiers.

### DIFF
--- a/api/models/miv/author-publications.tpl.rq
+++ b/api/models/miv/author-publications.tpl.rq
@@ -1,19 +1,19 @@
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX bibo: <http://purl.org/ontology/bibo/>
-PREFIX vivo: <http://vivoweb.org/ontology/core#>
-PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
-PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-PREFIX cito: <http://purl.org/spar/cito/>
-PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
-PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX purl: <http://purl.org/ontology/bibo/>
-PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf>
 PREFIX cite: <http://citationstyles.org/schema/>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX experts: <http://experts.ucdavis.edu/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX purl: <http://purl.org/ontology/bibo/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
+PREFIX vivo: <http://vivoweb.org/ontology/core#>
+PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 SELECT ?publication
 WHERE {

--- a/api/models/miv/index.js
+++ b/api/models/miv/index.js
@@ -13,8 +13,8 @@ class Miv {
   }
 
   async export(user) {
-    if( !user.match(/^ucdrp:/) ) {
-      user = 'ucdrp:'+user;
+    if( !user.match(/^experts:/) ) {
+      user = 'experts:'+user;
     }
 
     let q = this.QUERIES.AUTHOR_PUBS.replace(/{{username}}/, user);
@@ -32,7 +32,7 @@ class Miv {
       pubs[i] = this.formatAuthors(this.getPub(graph), graph);
       // if( i === 5 ) break;
     }
-    
+
     return citation.convert(pubs);
   }
 
@@ -40,8 +40,8 @@ class Miv {
     if( !Array.isArray(graph) ) return graph;
 
     return graph.find(
-      item => Array.isArray(item['@type']) ? 
-        item['@type'].includes('bibo:AcademicArticle') : 
+      item => Array.isArray(item['@type']) ?
+        item['@type'].includes('bibo:AcademicArticle') :
         item['@type'] === 'bibo:AcademicArticle'
       );
   }

--- a/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/organization.tpl.rq
@@ -7,7 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 
 CONSTRUCT {
   ?subject rdf:type ?type .

--- a/es-indexer/lib/es-sparql-model/default-queries/person-citations.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person-citations.tpl.rq
@@ -7,8 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucd: <http://experts.ucdavis.edu/schema#>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 
 CONSTRUCT {
   ?subject rdf:type ?type .
@@ -52,6 +51,6 @@ CONSTRUCT {
   }
 
   FILTER(
-    ?subject = "{{uri}}" && 
+    ?subject = "{{uri}}" &&
     ?authorPersonType IN (vcard:Individual, vivo:FacultyMember, vivo:NonAcademic, foaf:Person))
 }

--- a/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/person.tpl.rq
@@ -7,8 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucd: <http://experts.ucdavis.edu/schema#>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX free: <http://experts.ucdavis.edu/sub/free#>
 PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>
@@ -23,7 +22,7 @@ CONSTRUCT {
   ?subject vivo:eRACommonsId ?eRACommonsId .
   ?subject vivo:overview ?overview .
 
-  ?subject ucd:casId ?casId .
+  ?subject ucdrp:casId ?casId .
 
   ?subject vivo:orcidId ?orcidId .
   ?orcidId vivo:confirmedOrcidId ?confirmedOrcidId .
@@ -48,7 +47,7 @@ CONSTRUCT {
   ?contactInfoFor vcard:telephone ?telephone .
   ?contactInfoFor vcard:geo ?geo .
   ?contactInfoFor vivo:rank ?vcardRank .
-  ?contactInfoFor ucd:identifier ?identifier .
+  ?contactInfoFor ucdrp:identifier ?identifier .
 
   ?contactInfoFor vcard:hasURL ?vcardURL .
   ?vcardURL vcard:url ?url .
@@ -74,7 +73,7 @@ CONSTRUCT {
     OPTIONAL { ?subject vivo:eRACommonsId ?eRACommonsId . }
     OPTIONAL { ?subject vivo:overview ?overview . }
 
-    OPTIONAL { ?subject ucd:casId ?casId . }
+    OPTIONAL { ?subject ucdrp:casId ?casId . }
 
     OPTIONAL {
       ?subject vivo:orcidId ?orcidId .
@@ -100,7 +99,7 @@ CONSTRUCT {
       }
 
       OPTIONAL { ?contactInfoFor vivo:rank ?vcardRank . }
-      OPTIONAL { ?contactInfoFor ucd:identifier ?identifier . }
+      OPTIONAL { ?contactInfoFor ucdrp:identifier ?identifier . }
 
       OPTIONAL {
         ?contactInfoFor vcard:hasEmail ?vcardEmail .

--- a/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/publication.tpl.rq
@@ -7,7 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX free: <http://experts.ucdavis.edu/sub/free#>
 PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>

--- a/es-indexer/lib/es-sparql-model/default-queries/subject-area.tpl.rq
+++ b/es-indexer/lib/es-sparql-model/default-queries/subject-area.tpl.rq
@@ -7,8 +7,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX cito: <http://purl.org/spar/cito/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX ucd: <http://experts.ucdavis.edu/schema#>
-PREFIX ucdrp: <http://experts.library.ucdavis.edu/individual/>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX free: <http://experts.ucdavis.edu/sub/free#>
 PREFIX for: <http://experts.ucdavis.edu/sub/FoR#>
@@ -25,7 +24,7 @@ CONSTRUCT {
   ?subject skos:broader ?broader .
   ?broader rdfs:label ?broaderLabel .
   ?broader skos:prefLabel ?broaderPrefLabel .
-  
+
   ?subject skos:narrower ?narrower .
   ?narrower rdfs:label ?narrowerLabel .
   ?narrower skos:prefLabel ?narrowerPrefLabel .
@@ -38,13 +37,13 @@ CONSTRUCT {
   OPTIONAL { ?subject skos:prefLabel ?prefLabel . }
 
   OPTIONAL { ?subject skos:inSchema ?inSchema .  }
-  OPTIONAL { 
-    ?subject skos:broader ?broader . 
+  OPTIONAL {
+    ?subject skos:broader ?broader .
     ?broader rdfs:label ?broaderLabel .
     OPTIONAL { ?broader skos:prefLabel ?broaderPrefLabel . }
   }
-  OPTIONAL { 
-    ?subject skos:narrower ?narrower . 
+  OPTIONAL {
+    ?subject skos:narrower ?narrower .
     ?narrower rdfs:label ?narrowerLabel .
     OPTIONAL { ?narrower skos:prefLabel ?narrowerPrefLabel . }
   }

--- a/node-utils/lib/config.js
+++ b/node-utils/lib/config.js
@@ -65,8 +65,8 @@ module.exports = {
     database : env.FUSEKI_DATABASE || 'vivo',
     graphs,
     rootPrefix : {
-      uri : 'http://experts.library.ucdavis.edu/individual/',
-      prefix: 'ucdrp'
+      uri : 'http://experts.ucdavis.edu/',
+      prefix: 'experts'
     }
   },
 


### PR DESCRIPTION
This was my first try at the required updates for the new identifier standardizing for the version 2.0 of the experts system.  The main thrusts are :  1) base moves from `experts.library.ucdavis.edu/individual/` to `experts.ucdavis.edu/` and conflating together the `ucd:` and `ucdrp:` to a common schema.
