### PR TITLE
Include More citations in RIS export

### DIFF
--- a/api/lib/citation.js
+++ b/api/lib/citation.js
@@ -9,6 +9,8 @@ class Citation {
   convert(data, opts={}) {
     // if( !opts.style ) opts.style = 'ris';
     // opts.format = 'string';
+      console.log('Quinn is Great');
+      console.log(data);
 
     // HACK for demo
     data = data.map(item => {
@@ -23,8 +25,8 @@ class Citation {
       if( item.venue ) {
         item.venue = {id: item.venue};
       }
-      item.type = 'article';
-
+//      item.type = 'article';
+      console.log(item);
       return item;
     });
 

--- a/api/models/miv/author-publications.tpl.rq
+++ b/api/models/miv/author-publications.tpl.rq
@@ -1,27 +1,15 @@
-PREFIX bibo: <http://purl.org/ontology/bibo/>
-PREFIX cite: <http://citationstyles.org/schema/>
-PREFIX cito: <http://purl.org/spar/cito/>
-PREFIX experts: <http://experts.ucdavis.edu/schema#>
-PREFIX ucdrp: <http://experts.ucdavis.edu/>
-PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
-PREFIX obo: <http://purl.obolibrary.org/obo/>
-PREFIX purl: <http://purl.org/ontology/bibo/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
 PREFIX vivo: <http://vivoweb.org/ontology/core#>
-PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
 
 SELECT ?publication
 WHERE {
   bind ({{username}} as ?author)
 
-  ?subject rdf:type vivo:Authorship .
-  ?subject vivo:relates ?author .
-  ?subject vivo:relates ?publication .
-  ?publication rdf:type bibo:AcademicArticle .
+  ?subject a vivo:Authorship;
+           vivo:relates ?author;
+           vivo:relates ?publication;
+           .
+  ?publication a ucdrp:work;
+               .
 }

--- a/api/models/miv/index.js
+++ b/api/models/miv/index.js
@@ -30,9 +30,10 @@ class Miv {
 
       let resp = await fuseki.query(q, 'application/ld+json');
       let graph = await resp.json();
-
       graph = graph['@graph'] ? graph['@graph'] : graph;
+      console.log(graph);
       pubs[i] = this.formatAuthors(this.getPub(graph), graph);
+      console.log(pubs[i])
       // if( i === 5 ) break;
 
       // TODO: test

--- a/api/models/miv/index.js
+++ b/api/models/miv/index.js
@@ -51,8 +51,8 @@ class Miv {
 
     return graph.find(
       item => Array.isArray(item['@type']) ?
-        item['@type'].includes('bibo:AcademicArticle') :
-        item['@type'] === 'bibo:AcademicArticle'
+        item['@type'].includes('ucdrp:work') :
+        item['@type'] === 'ucdrp:work'
       );
   }
 

--- a/api/models/miv/publications.tpl.rq
+++ b/api/models/miv/publications.tpl.rq
@@ -1,33 +1,36 @@
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> 
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> 
-PREFIX bibo: <http://purl.org/ontology/bibo/> 
-PREFIX vivo: <http://vivoweb.org/ontology/core#> 
-PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> 
-PREFIX foaf: <http://xmlns.com/foaf/0.1/> 
-PREFIX vcard: <http://www.w3.org/2006/vcard/ns#> 
-PREFIX cito: <http://purl.org/spar/cito/> 
-PREFIX obo: <http://purl.obolibrary.org/obo/> 
-PREFIX experts: <http://experts.ucdavis.edu/#schema> 
-PREFIX ucdrp: <http://experts.ucdavis.edu/> 
-PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#> 
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#> 
-PREFIX purl: <http://purl.org/ontology/bibo/> 
-PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf> 
-PREFIX cite: <http://citationstyles.org/schema/>  
+PREFIX bibo: <http://purl.org/ontology/bibo/>
+PREFIX cite: <http://citationstyles.org/schema/>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX purl: <http://purl.org/ontology/bibo/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX ucdrp: <http://experts.ucdavis.edu/schema#>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#>
+PREFIX vivo: <http://vivoweb.org/ontology/core#>
+PREFIX vivo_inf: <http://vitro.mannlib.cornell.edu/default/vitro-kb-inf>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 CONSTRUCT {
 
-  ?pub rdf:type ?type ;
-  ?pub_cp ?o ;
-  cite:page ?page;
-  cite:venue ?venue;
-  cite:container-title ?venue_title;
-  cite:ISSN ?venue_issn;
-  cite:issued ?issued;
-  cite:citation-label ?pub_id;
-  cite:author ?a.
-  ?a cite:rank ?rank; ?vname_cp ?vname_obj.
+  ?pub rdf:type ?type;
+       ?pub_cp ?o;
+       cite:page ?page;
+       cite:venue ?venue;
+       cite:container-title ?venue_title;
+       cite:ISSN ?venue_issn;
+       cite:issued ?issued;
+       cite:citation-label ?pub_id;
+       cite:author ?a;
+       .
+
+  ?a cite:rank ?rank;
+     ?vname_cp ?vname_obj;
+     .
 
 } WHERE {
 
@@ -51,7 +54,7 @@ CONSTRUCT {
   }
 
   GRAPH ?g {
-    bind(replace(str(?pub),str(ucdrp:),"") as ?pub_id)
+    bind(replace(str(?pub),str(<http://experts.ucdavis.edu/>),"") as ?pub_id)
     ?pub rdf:type ?type ;
       ?pub_p ?o ;
       vivo:relatedBy ?authorship .

--- a/api/models/miv/publications.tpl.rq
+++ b/api/models/miv/publications.tpl.rq
@@ -21,7 +21,6 @@ CONSTRUCT {
   ?pub a ?type;
        ?pub_cp ?o;
        cite:type ?cite_type;
-       cite:subtype ?cite_subtype;
        cite:page ?page;
        cite:venue ?venue;
        cite:container-title ?venue_title;
@@ -38,18 +37,6 @@ CONSTRUCT {
 } WHERE {
 
   bind (<{{publication}}> as ?pub)
-
-  values (?type ?cite_type ) {
-    (bibo:AcademicArticle 'article-journal')
-    (bibo:Book 'book')
-    (bibo:Chapter 'chapter')
-    (vivo:ConferencePaper 'paper-conference')
-    (ucdrp:PrePrint 'article')
-  }
-
-  values (?type ?cite_subtype ) {
-    (ucdrp:PrePrint 'preprint')
-  }
 
   values(?pub_p ?pub_cp) {
     (rdfs:label cite:title)
@@ -70,6 +57,19 @@ CONSTRUCT {
 
   GRAPH ?g {
     bind(replace(str(?pub),str(<http://experts.ucdavis.edu/>),"") as ?pub_id)
+
+    {
+      select ?pub (max(?ct) as ?cite_type) WHERE {
+	      values (?type ?ct ) {
+    	  (bibo:AcademicArticle 'article-journal')
+        (bibo:Book 'book')
+        (bibo:Chapter 'chapter')
+        (vivo:ConferencePaper 'paper-conference')
+        (ucdrp:PrePrint 'article') }
+        ?pub a ?type
+      } group by ?pub
+    }
+
     ?pub rdf:type ?type ;
       ?pub_p ?o ;
       vivo:relatedBy ?authorship .

--- a/api/models/miv/publications.tpl.rq
+++ b/api/models/miv/publications.tpl.rq
@@ -1,6 +1,7 @@
 PREFIX bibo: <http://purl.org/ontology/bibo/>
 PREFIX cite: <http://citationstyles.org/schema/>
 PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX experts: <http://experts.ucdavis.edu>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX meshv: <http://id.nlm.nih.gov/mesh/vocab#>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
@@ -17,7 +18,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 CONSTRUCT {
 
-  ?pub rdf:type ?type;
+  ?pub a ?type;
        ?pub_cp ?o;
        cite:type ?cite_type;
        cite:subtype ?cite_subtype;

--- a/api/models/miv/publications.tpl.rq
+++ b/api/models/miv/publications.tpl.rq
@@ -19,6 +19,8 @@ CONSTRUCT {
 
   ?pub rdf:type ?type;
        ?pub_cp ?o;
+       cite:type ?cite_type;
+       cite:subtype ?cite_subtype;
        cite:page ?page;
        cite:venue ?venue;
        cite:container-title ?venue_title;
@@ -35,6 +37,18 @@ CONSTRUCT {
 } WHERE {
 
   bind (<{{publication}}> as ?pub)
+
+  values (?type ?cite_type ) {
+    (bibo:AcademicArticle 'article-journal')
+    (bibo:Book 'book')
+    (bibo:Chapter 'chapter')
+    (vivo:ConferencePaper 'paper-conference')
+    (ucdrp:PrePrint 'article')
+  }
+
+  values (?type ?cite_subtype ) {
+    (ucdrp:PrePrint 'preprint')
+  }
 
   values(?pub_p ?pub_cp) {
     (rdfs:label cite:title)


### PR DESCRIPTION
This addresses #58 

This PR will now download all citations to RIS format.  There is a caveat however.

We have added a ucdrp:PrePrint type to the citation types.  The RIS format is performed by converting our citation into citeproc, and from there converting to RIS.  

According the the citeproc [Types](https://docs.citationstyles.org/en/v1.1/specification.html#appendix-iii-types), preprints should be specified as `articles` which they are.  However [RIS format types](https://en.wikipedia.org/wiki/RIS_(file_format)#Type_of_reference) does *not* include a `preprint` type,  it does include an `INPR` type, but those aren't exactly the same.

Regardless, when citration.js translates from a cite.json file to an RIS file, it uses these [mappings](https://github.com/citation-js/citation-js/blob/3f3eee0813c7d578a454c34e402fa342d0693cfa/packages/plugin-ris/src/spec/types.json).  In this setup both journal articles and articles are translated to `JOUR` and so the import will not be able to differentiate them.